### PR TITLE
Bug Fixes

### DIFF
--- a/mern/client/src/Components/Navbar/navbar.component.js
+++ b/mern/client/src/Components/Navbar/navbar.component.js
@@ -70,22 +70,10 @@ export default function Navbar() {
       } else {
         alert("Successfully Deleted");
 
-        // Resets all contexts to original value
-        setSessionID(null);
-        setcurrQAState({});
-        setFlowState({});
-        setFlowStartingQuestions([]);
-        setFlowAllQuestions([]);
-        setSpeaker("User:");
-        setPrevSpeaker("Bot:");
-        setQuestionState([]);
-        setNextQuestions([]);
-        setAllQuestions([]);
-        setPrevPrompt('"How can I help you today?"');
-        setSpeechList([]);
-        setTranscriptID(null);
-        setIntentState({});
         PageChange("/");
+
+        // Resets all contexts to original value\
+        resetContext();
 
         // Disables continue button by resets intentState values to 0
         Object.keys(intentState).forEach((key) => {
@@ -93,6 +81,23 @@ export default function Navbar() {
         });
       }
     });
+  };
+
+  const resetContext = () => {
+    setSessionID(null);
+    setcurrQAState({});
+    setFlowState({});
+    setFlowStartingQuestions([]);
+    setFlowAllQuestions([]);
+    setSpeaker("User:");
+    setPrevSpeaker("Bot:");
+    setQuestionState([]);
+    setNextQuestions([]);
+    setAllQuestions([]);
+    setPrevPrompt('"How can I help you today?"');
+    setSpeechList([]);
+    setTranscriptID(null);
+    setIntentState({});
   };
 
   return (

--- a/mern/client/src/Components/Navbar/navbar.component.js
+++ b/mern/client/src/Components/Navbar/navbar.component.js
@@ -7,21 +7,39 @@ import { SessionContext } from "../../Contexts/sessionProvider";
 import { qaContext } from "../../Contexts/qaProvider";
 import { FlowContext } from "../../Contexts/flowProvider";
 import { deleteFlow } from "../../utils/delete";
-import { saveFlow, saveQA } from "../../utils/save";
+import { saveSession } from "../../utils/save";
 import { IntentContext } from "../../Contexts/intentsProvider";
+import { QuestionContext } from "../../Contexts/questionProvider";
+import { ScrollerContext } from "../../Contexts/scrollerProvider";
+import { SpeakerContext } from "../../Contexts/speakerProvider";
 
 export default function Navbar() {
   // define context var to show/hide nav buttons
-  const [sessionID, setSessionID] = useContext(SessionContext);
-  const [currQA] = useContext(qaContext);
-  const [currFlow, , , , ,] = useContext(FlowContext);
-  const [intentState] = useContext(IntentContext);
+  const [currQA, setcurrQAState] = useContext(qaContext);
+  const [
+    currFlow,
+    setFlowState,
+    ,
+    setFlowStartingQuestions,
+    ,
+    setFlowAllQuestions,
+  ] = useContext(FlowContext);
+  const [intentState, setIntentState] = useContext(IntentContext);
+  const [, setSpeaker, , setPrevSpeaker] = useContext(SpeakerContext);
+  const [
+    ,
+    setQuestionState,
+    ,
+    setNextQuestions,
+    ,
+    setAllQuestions,
+    ,
+    setPrevPrompt,
+  ] = useContext(QuestionContext);
+  const [, setSpeechList] = useContext(ScrollerContext);
+  const [sessionID, setSessionID, , setTranscriptID] =
+    useContext(SessionContext);
 
-  // Create session id var and setter function
-  // const sessionid = "12345";
-  // const setSessionID = (id) => {
-  //   sessionid = id;
-  // };
   const Navigate = useNavigate();
   const PageChange = (url) => {
     Navigate(url);
@@ -29,22 +47,14 @@ export default function Navbar() {
 
   // This function is called when user clicks save button and saves the current question
   const trySave = (currFlow, currQA, sessionID) => {
-    saveQA(currQA).then((res) => {
+    saveSession(currFlow, currQA, sessionID).then((res) => {
       if (!res) {
-        alert("Unable to Delete");
+        alert("Unable to Save");
+      } else {
+        alert("Saved Successfully");
+        PageChange("/save");
       }
     });
-
-    saveFlow(currFlow, currQA, sessionID).then((res) => {
-      if (!res) {
-        alert("Unable to Delete");
-        return;
-      }
-    });
-
-    alert("Saved Successfully");
-
-    PageChange("/save");
 
     // Disables continue button by resets intentState values to 0
     Object.keys(intentState).forEach((key) => {
@@ -59,14 +69,29 @@ export default function Navbar() {
         alert("Unable to Delete");
       } else {
         alert("Successfully Deleted");
-      }
-    });
-    setSessionID(null);
-    PageChange("/");
 
-    // Disables continue button by resets intentState values to 0
-    Object.keys(intentState).forEach((key) => {
-      intentState[key] = 0;
+        // Resets all contexts to original value
+        setSessionID(null);
+        setcurrQAState({});
+        setFlowState({});
+        setFlowStartingQuestions([]);
+        setFlowAllQuestions([]);
+        setSpeaker("User:");
+        setPrevSpeaker("Bot:");
+        setQuestionState([]);
+        setNextQuestions([]);
+        setAllQuestions([]);
+        setPrevPrompt('"How can I help you today?"');
+        setSpeechList([]);
+        setTranscriptID(null);
+        setIntentState({});
+        PageChange("/");
+
+        // Disables continue button by resets intentState values to 0
+        Object.keys(intentState).forEach((key) => {
+          intentState[key] = 0;
+        });
+      }
     });
   };
 

--- a/mern/client/src/screens/SavingSession/savingSession.js
+++ b/mern/client/src/screens/SavingSession/savingSession.js
@@ -81,6 +81,21 @@ export default function SavingSession() {
   };
 
   const resetEnd = () => {
+    resetContext();
+  };
+
+  const resetGoBack = () => {
+    // Need to pop the most recent item from the transcript list if it is a question
+    if (currSpeaker === "Bot:") {
+      speechList.pop();
+      const temp = speechList;
+      setSpeechList(temp);
+      setSpeaker("User:");
+      setPrevSpeaker("Bot:");
+    }
+  };
+
+  const resetContext = () => {
     setSessionID(null);
     setcurrQAState({});
     setFlowState({});
@@ -95,16 +110,6 @@ export default function SavingSession() {
     setSpeechList([]);
     setTranscriptID(null);
     setIntentState({});
-  };
-
-  const resetGoBack = () => {
-    // Need to pop the most recent item from the transcript list if it is a question
-    if (currSpeaker === "Bot:") {
-      speechList.pop();
-      const temp = speechList;
-      setSpeechList(temp);
-      setPrevSpeaker("Bot:");
-    }
   };
 
   return (

--- a/mern/client/src/screens/SavingSession/savingSession.js
+++ b/mern/client/src/screens/SavingSession/savingSession.js
@@ -102,7 +102,6 @@ export default function SavingSession() {
     if (currSpeaker === "Bot:") {
       speechList.pop();
       const temp = speechList;
-      console.log(temp);
       setSpeechList(temp);
       setPrevSpeaker("Bot:");
     }

--- a/mern/client/src/screens/SavingSession/savingSession.js
+++ b/mern/client/src/screens/SavingSession/savingSession.js
@@ -2,14 +2,42 @@ import React, { useContext, useState, useEffect } from "react";
 import styles from "./savingSession.module.css";
 import GenericButton from "../../Components/Buttons/GenericButton";
 import { useNavigate } from "react-router-dom";
-import { SessionContext } from "../../Contexts/sessionProvider";
 import Modal from "../../Components/Modals/GenericModal";
 import emailjs from "emailjs-com";
 import { FlowContext } from "../../Contexts/flowProvider";
+import { SessionContext } from "../../Contexts/sessionProvider";
+import { qaContext } from "../../Contexts/qaProvider";
+import { IntentContext } from "../../Contexts/intentsProvider";
+import { QuestionContext } from "../../Contexts/questionProvider";
+import { ScrollerContext } from "../../Contexts/scrollerProvider";
+import { SpeakerContext } from "../../Contexts/speakerProvider";
 
 export default function SavingSession() {
-  const [currFlow, , , , , ,] = useContext(FlowContext);
-  const [sessionID, , ,] = useContext(SessionContext);
+  const [
+    currFlow,
+    setFlowState,
+    ,
+    setFlowStartingQuestions,
+    ,
+    setFlowAllQuestions,
+  ] = useContext(FlowContext);
+  const [, setcurrQAState] = useContext(qaContext);
+  const [, setIntentState] = useContext(IntentContext);
+  const [currSpeaker, setSpeaker, , setPrevSpeaker] =
+    useContext(SpeakerContext);
+  const [
+    ,
+    setQuestionState,
+    ,
+    setNextQuestions,
+    ,
+    setAllQuestions,
+    ,
+    setPrevPrompt,
+  ] = useContext(QuestionContext);
+  const [speechList, setSpeechList] = useContext(ScrollerContext);
+  const [sessionID, setSessionID, , setTranscriptID] =
+    useContext(SessionContext);
   const [showModal, setShowModal] = useState(false);
   const [email, setEmail] = useState("");
   const [validEmail, setValidEmail] = useState(true);
@@ -50,6 +78,34 @@ export default function SavingSession() {
           console.log(error.text);
         }
       );
+  };
+
+  const resetEnd = () => {
+    setSessionID(null);
+    setcurrQAState({});
+    setFlowState({});
+    setFlowStartingQuestions([]);
+    setFlowAllQuestions([]);
+    setSpeaker("User:");
+    setPrevSpeaker("Bot:");
+    setQuestionState([]);
+    setNextQuestions([]);
+    setAllQuestions([]);
+    setPrevPrompt('"How can I help you today?"');
+    setSpeechList([]);
+    setTranscriptID(null);
+    setIntentState({});
+  };
+
+  const resetGoBack = () => {
+    // Need to pop the most recent item from the transcript list if it is a question
+    if (currSpeaker === "Bot:") {
+      speechList.pop();
+      const temp = speechList;
+      console.log(temp);
+      setSpeechList(temp);
+      setPrevSpeaker("Bot:");
+    }
   };
 
   return (
@@ -106,15 +162,18 @@ export default function SavingSession() {
         <div className={styles.buttonRow}>
           <GenericButton
             buttonType="blue"
-            onClick={() => PageChange("/")}
+            onClick={() => {
+              PageChange("/");
+              resetEnd();
+            }}
             disabled={false}
             text={"End Session"}
           />
           <GenericButton
             buttonType="outline"
             onClick={() => {
-              // Logic goes here if
               PageChange("/startingintent");
+              resetGoBack();
             }}
             disabled={false}
             text={"Go Back"}

--- a/mern/client/src/utils/save.js
+++ b/mern/client/src/utils/save.js
@@ -1,28 +1,34 @@
 import axios from "axios";
 
-// Takes in a qa object and sessionID and updates the flow object
-export async function saveQA(qa) {
-  var saved = false;
-  await axios.put("http://localhost:5000/qa/update", qa).then((res) => {
+export async function saveSession(flow, qa, sessionID) {
+  var checkFlow = false;
+  await saveFlow(flow, qa, sessionID).then((res) => {
     if (res.status === 200) {
-      saved = true;
+      checkFlow = true;
     }
   });
-  return saved;
+
+  var checkQA = false;
+  await saveQA(qa).then((res) => {
+    if (res.status === 200) {
+      checkQA = true;
+    }
+  });
+
+  return checkFlow && checkQA;
+}
+
+// Takes in a qa object and sessionID and updates the flow object
+export async function saveQA(qa) {
+  return await axios.put("http://localhost:5000/qa/update", qa);
 }
 
 // Takes in the flow object, current question and session id to update the flow parameter with
 // the current question
 export async function saveFlow(flow, qa, sessionID) {
   flow.current_question = qa.id;
-  var saved = false;
-  await axios
-    .put(`http://localhost:5000/flow/update/${sessionID}`, flow)
-    .then((res) => {
-      if (res.status === 200) {
-        saved = true;
-      }
-    });
-
-  return saved;
+  return await axios.put(
+    `http://localhost:5000/flow/update/${sessionID}`,
+    flow
+  );
 }


### PR DESCRIPTION
# Description

Fixed bugs with transcript scroller display and context reset when moving between pages.

Fixes # (issue)

1. On deletion, contexts held previous values. Hence, reset all contexts to the initial value when the user deleted their session.
2. On the save page, the end session button should also reset all contexts to default values.
3. On the save page, the go-back button, needs to pop the most recent question off the transcript scroller if the current speaker is a bot. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Checked UI to see appropriate changes. (Console Log Values)


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
